### PR TITLE
Revise homepage card colors and hero logo

### DIFF
--- a/clearcomply-hr-site_v6/assets/css/styles.css
+++ b/clearcomply-hr-site_v6/assets/css/styles.css
@@ -46,11 +46,17 @@ a{color:var(--navy); text-decoration:none}
 .hero::after{
   content:"";
   position:absolute;
-  top:20px; right:20px;
-  width:120px; height:120px;
+  top:50%;
+  left:50%;
+  width:600px;
+  height:600px;
+  transform:translate(-50%, -50%);
   background:url('../img/logo.png') center/contain no-repeat;
-  opacity:0.12; pointer-events:none;
+  opacity:0.08;
+  pointer-events:none;
+  z-index:0;
 }
+.hero > .container{position:relative; z-index:1}
 .hero h1{font-size:40px; line-height:1.15; margin:0 0 10px; color:var(--ink)}
 .hero p.sub{font-size:18px; max-width:720px}
 .actions{display:flex; gap:14px; margin-top:20px; flex-wrap:wrap}
@@ -113,8 +119,9 @@ button{font:inherit}
 hr.sep{border:0; border-top:1px solid #e7eef6; margin:28px 0}
 
 /* Problem → Solution cards */
-.card-rose{background:#fff5f5; border-color:#ffd9d9}
-.card-teal{background:#e6f8f5; border-color:#c8efe8}
+/* Use muted palettes that complement site colors */
+.card-rose{background:#e9f0f5; border-color:#cdd9e3}
+.card-teal{background:#f0f7f6; border-color:#d0e9e4}
 .probsol{display:grid; grid-template-columns:repeat(2,1fr); gap:20px}
 
 /* Mobile */
@@ -129,5 +136,5 @@ hr.sep{border:0; border-top:1px solid #e7eef6; margin:28px 0}
   .nav-links{display:none}
   .nav.open .nav-links{display:flex; flex-direction:column; gap:12px; margin-top:12px}
   .probsol{grid-template-columns:1fr}
-  .hero::after{ width:96px; height:96px; top:12px; right:12px }
+  .hero::after{ width:300px; height:300px; top:50%; left:50%; transform:translate(-50%, -50%); }
 }

--- a/clearcomply-hr-site_v6/index.html
+++ b/clearcomply-hr-site_v6/index.html
@@ -82,7 +82,7 @@
       </div>
       <div class="card">
         <span class="badge">Tracking</span>
-        <h3>Credentials &amp; immunizations</h3>
+        <h3>Credentials Tracking</h3>
         <p>Licenses, CPR/BLS, TB/PPD, Hep B, Flu — renewal reminders for staff and admins.</p>
       </div>
       <div class="card">


### PR DESCRIPTION
## Summary
- Soften problem/solution card backgrounds to muted blues and greens
- Rename tracking card to "Credentials Tracking"
- Enlarge translucent hero logo behind headline with responsive sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a128970aec8332be4700296d661a46